### PR TITLE
Api keys update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-src/scripts/api/api-keys.js
+src/scripts/apiManager/api-keys.js
 .DS_Store

--- a/src/scripts/apiManager/art-api-manager.js
+++ b/src/scripts/apiManager/art-api-manager.js
@@ -1,0 +1,1 @@
+// Test commit to confirm that api-keys.js is now ignored


### PR DESCRIPTION
I noticed the api-keys.js file was not actually ignored, due to the file structure changing from api to apiManager. 

I've updated that path in .gitignore, deleted the tracked api-keys.js and am looking to merge those changes into master so it is no longer tracked. 

Please pull down this branch (api-keys-update) and confirm that:
- apiManager folder does not contain api-keys.js