### PR TITLE
completed the no-results-found conditional

### DIFF
--- a/src/scripts/DOM/concertResultsManager.js
+++ b/src/scripts/DOM/concertResultsManager.js
@@ -17,12 +17,16 @@ const concertSearchResultsDomManager = {
         `
     },
     renderSearchResults(searchResults) {
-        const concerts = searchResults._embedded.events
         const container = document.querySelector("#resultsContainer");
         container.innerHTML = "<h2>Concert Results</h2>";
-        concerts.forEach(concert => {
-          container.innerHTML += this.concertFactory(concert)
-        });
+        if (searchResults.hasOwnProperty('_embedded')) {
+            const concerts = searchResults._embedded.events
+            concerts.forEach(concert => {
+                container.innerHTML += this.concertFactory(concert);
+            })
+        } else {
+            container.innerHTML += "<p>No results available</p>"
+        }
         this.addSaveEventListener();
     },
     addSaveEventListener(){


### PR DESCRIPTION
The "No Results Found" conditional has been created for the concerts search. 

1. commit all current work
2. `git checkout kp-concerts-conditional`
3. `git pull origin kp-concerts-conditional`
4. Confirm in the browser:
- A search of nonsense characters in the concerts bar returns "No Results Found"
- A normal search still works (like "rock")